### PR TITLE
Adding mistakenly omitted file from previous commit for device config…

### DIFF
--- a/com.amd.aparapi/src/java/com/amd/aparapi/Kernel.java
+++ b/com.amd.aparapi/src/java/com/amd/aparapi/Kernel.java
@@ -2154,12 +2154,6 @@ public abstract class Kernel implements Cloneable {
       }
    }
 
-   /** Automatically releases any resources associated with this Kernel when the Kernel is garbage collected. */
-   @Override
-   protected void finalize() {
-      dispose();
-   }
-
    public boolean isRunningCL() {
       return getTargetDevice() instanceof OpenCLDevice;
    }

--- a/com.amd.aparapi/src/java/com/amd/aparapi/Range.java
+++ b/com.amd.aparapi/src/java/com/amd/aparapi/Range.java
@@ -140,6 +140,15 @@ public class Range extends RangeJNI{
    public static Range create(Device _device, int _globalWidth) {
       final Range withoutLocal = create(_device, _globalWidth, 1);
 
+      if (_device == JavaDevice.THREAD_POOL) {
+         withoutLocal.setLocalSize_0(Runtime.getRuntime().availableProcessors());
+         withoutLocal.setLocalIsDerived(true);
+         return withoutLocal;
+      } else if (_device instanceof JavaDevice) {
+         withoutLocal.setLocalIsDerived(true);
+         return withoutLocal;
+      }
+
       if (_globalWidth == 0) {
          withoutLocal.setLocalIsDerived(true);
          return withoutLocal;

--- a/com.amd.aparapi/src/java/com/amd/aparapi/internal/kernel/KernelPreferences.java
+++ b/com.amd.aparapi/src/java/com/amd/aparapi/internal/kernel/KernelPreferences.java
@@ -1,0 +1,78 @@
+package com.amd.aparapi.internal.kernel;
+
+import com.amd.aparapi.*;
+import com.amd.aparapi.device.*;
+
+import java.util.*;
+
+public class KernelPreferences {
+   private final Class<? extends Kernel> kernelClass;
+   private final KernelManager manager;
+   private volatile LinkedList<Device> preferredDevices = null;
+   private final LinkedHashSet<Device> failedDevices = new LinkedHashSet<>();
+
+   public KernelPreferences(KernelManager manager, Class<? extends Kernel> kernelClass) {
+      this.kernelClass = kernelClass;
+      this.manager = manager;
+   }
+
+   /** What Kernel subclass is this the preferences for? */
+   public Class<? extends Kernel> getKernelClass() {
+      return kernelClass;
+   }
+
+   public List<Device> getPreferredDevices(Kernel kernel) {
+      maybeSetUpDefaultPreferredDevices();
+
+      if (kernel == null) {
+         return Collections.unmodifiableList(preferredDevices);
+      }
+      List<Device> localPreferredDevices = new ArrayList<>();
+      ArrayList<Device> copy;
+      synchronized (preferredDevices) {
+         copy = new ArrayList(preferredDevices);
+      }
+      for (Device device : copy) {
+         if (kernel.isAllowDevice(device)) {
+            localPreferredDevices.add(device);
+         }
+      }
+      return Collections.unmodifiableList(localPreferredDevices);
+   }
+
+   synchronized void setPreferredDevices(LinkedHashSet<Device> _preferredDevices) {
+      if (preferredDevices != null) {
+         preferredDevices.clear();
+         preferredDevices.addAll(_preferredDevices);
+      }
+      else {
+         preferredDevices = new LinkedList<>(_preferredDevices);
+      }
+      failedDevices.clear();
+   }
+
+   public Device getPreferredDevice(Kernel kernel) {
+      List<Device> localPreferredDevices = getPreferredDevices(kernel);
+      return localPreferredDevices.isEmpty() ? null : localPreferredDevices.get(0);
+   }
+
+   synchronized void markPreferredDeviceFailed() {
+      if (preferredDevices.size() > 0) {
+         failedDevices.add(preferredDevices.remove(0));
+      }
+   }
+
+   private void maybeSetUpDefaultPreferredDevices() {
+      if (preferredDevices == null) {
+         synchronized (this) {
+            if (preferredDevices == null) {
+               preferredDevices = new LinkedList<>(manager.getDefaultPreferences().getPreferredDevices(null));
+            }
+         }
+      }
+   }
+
+   public List<Device> getFailedDevices() {
+      return new ArrayList<>(failedDevices);
+   }
+}

--- a/com.amd.aparapi/src/java/com/amd/aparapi/internal/kernel/KernelRunner.java
+++ b/com.amd.aparapi/src/java/com/amd/aparapi/internal/kernel/KernelRunner.java
@@ -187,8 +187,8 @@ public class KernelRunner extends KernelRunnerJNI{
     * 
     * @see KernelRunnerJNI#disposeJNI(long)
     */
-   public void dispose() {
-      if (args != null || kernel.isRunningCL()) {
+   public synchronized void dispose() {
+      if (kernel.isRunningCL()) {
          disposeJNI(jniContextHandle);
       }
       // We are using a shared pool, so there's no need no shutdown it when kernel is disposed

--- a/com.amd.aparapi/src/java/com/amd/aparapi/internal/model/ClassModel.java
+++ b/com.amd.aparapi/src/java/com/amd/aparapi/internal/model/ClassModel.java
@@ -2815,7 +2815,6 @@ public class ClassModel {
          long s = System.nanoTime();
          Entrypoint entrypointWithoutKernel = entrypointCache.computeIfAbsent(key);
          long e = System.nanoTime() - s;
-         System.out.println("newMethodModel: " + e / 1000000f);
          return entrypointWithoutKernel.cloneForKernel(_k);
       } else {
          final MethodModel method = getMethodModel(_entrypointName, _descriptor);


### PR DESCRIPTION
 Adding mistakenly omitted file from previous commit for device configurability, plus some minor cleanups:

Reverted Kernel#finalize, now not overridden (was disposing kernel but this caused problems due to threading).

Modified Range so that where auto-creating sizes (i.e. localIsDerived) for JavaDevices sizes are sensible (size = 1 for sequential, = Runtime.getRuntime().availableProcessors() for thread pool.