### PR TITLE
Include missing string headers for the string from char[] constructio…

### DIFF
--- a/com.amd.aparapi.jni/src/cpp/CLHelper.cpp
+++ b/com.amd.aparapi.jni/src/cpp/CLHelper.cpp
@@ -42,6 +42,7 @@
 #include <map>
 #include <vector>
 #include <stdio.h>
+#include <string>
 
 void setMap(std::map<cl_int, const char*>& errorMap) {
    errorMap[CL_SUCCESS]                         = "success";


### PR DESCRIPTION
…n. FreeBSD's compiler and stdlib combination otherwise throws an error.