### PR TITLE
Correct the execution condition for simple array of objects

### DIFF
--- a/com.amd.aparapi/src/java/com/amd/aparapi/internal/kernel/KernelManager.java
+++ b/com.amd.aparapi/src/java/com/amd/aparapi/internal/kernel/KernelManager.java
@@ -190,7 +190,7 @@ public class KernelManager {
                devices.addAll(gpus);
                break;
             case CPU:
-               devices.add(cpus.get(0));
+               devices.addAll(cpus);
                break;
             case JTP:
                devices.add(JavaDevice.THREAD_POOL);

--- a/com.amd.aparapi/src/java/com/amd/aparapi/internal/kernel/KernelRunner.java
+++ b/com.amd.aparapi/src/java/com/amd/aparapi/internal/kernel/KernelRunner.java
@@ -1371,11 +1371,12 @@ public class KernelRunner extends KernelRunnerJNI{
                            // args[i].type |= ARG_GLOBAL;
 
                            if (type.getName().startsWith("[L")) {
+                              args[i].setArray(null); // will get updated in updateKernelArrayRefs
                               args[i].setType(args[i].getType()
-                                    | (ARG_OBJ_ARRAY_STRUCT | ARG_WRITE | ARG_READ | ARG_APARAPI_BUFFER));
+                                    | (ARG_ARRAY | ARG_OBJ_ARRAY_STRUCT | ARG_WRITE | ARG_READ));
 
                               if (logger.isLoggable(Level.FINE)) {
-                                 logger.fine("tagging " + args[i].getName() + " as (ARG_OBJ_ARRAY_STRUCT | ARG_WRITE | ARG_READ)");
+                                 logger.fine("tagging " + args[i].getName() + " as (ARG_ARRAY | ARG_OBJ_ARRAY_STRUCT | ARG_WRITE | ARG_READ)");
                               }
                            } else if (type.getName().startsWith("[[")) {
 


### PR DESCRIPTION
The simple array of objects cannot executed correctly due to the kernel argument flags are incorrectly set. This ability has been lost in some previous commits. This PR brings it back.