### PR TITLE
Resolve exception in kernel.dispose() 

### DIFF
--- a/com.amd.aparapi.jni/src/cpp/runKernel/Aparapi.cpp
+++ b/com.amd.aparapi.jni/src/cpp/runKernel/Aparapi.cpp
@@ -422,10 +422,10 @@ void updateBuffer(JNIEnv* jenv, JNIContext* jniContext, KernelArg* arg, int& arg
             fprintf(stderr, "runKernel arg %d %s, length = %d\n", argIdx, arg->name, buffer->lens[i]);
          }
          argPos++;
-         status = clSetKernelArg(jniContext->kernel, argPos, sizeof(cl_uint), &(buffer->dims[i]));
-         if(status != CL_SUCCESS) throw CLException(status,"clSetKernelArg (buffer dimension)");
+         status = clSetKernelArg(jniContext->kernel, argPos, sizeof(cl_uint), &(buffer->offsets[i]));
+         if(status != CL_SUCCESS) throw CLException(status,"clSetKernelArg (buffer offset)");
          if (config->isVerbose()){
-            fprintf(stderr, "runKernel arg %d %s, dim = %d\n", argIdx, arg->name, buffer->dims[i]);
+            fprintf(stderr, "runKernel arg %d %s, offsets = %d\n", argIdx, arg->name, buffer->offsets[i]);
          }
       }
    }
@@ -469,7 +469,7 @@ void processArray(JNIEnv* jenv, JNIContext* jniContext, KernelArg* arg, int& arg
    arg->pin(jenv);
 
    if (config->isVerbose()) {
-      fprintf(stderr, "runKernel: arrayOrBuf ref %p, oldAddr=%p, newAddr=%p, ref.mem=%p isCopy=%s\n",
+      fprintf(stderr, "runKernel: array ref %p, oldAddr=%p, newAddr=%p, ref.mem=%p isCopy=%s\n",
             arg->arrayBuffer->javaArray, 
             prevAddr,
             arg->arrayBuffer->addr,
@@ -528,8 +528,11 @@ void processBuffer(JNIEnv* jenv, JNIContext* jniContext, KernelArg* arg, int& ar
       arg->aparapiBuffer->write.valid = false;
    }
 
+   // TODO: check if the object was moved and required re-flatten
+   arg->aparapiBuffer->flatten(jenv,arg);
+
    if (config->isVerbose()) {
-      fprintf(stderr, "runKernel: arrayOrBuf addr=%p, ref.mem=%p\n",
+      fprintf(stderr, "runKernel: Buf addr=%p, ref.mem=%p\n",
             arg->aparapiBuffer->data,
             arg->aparapiBuffer->mem);
       fprintf(stderr, "at memory addr %p, contents: ", arg->aparapiBuffer->data);

--- a/com.amd.aparapi.jni/src/cpp/runKernel/AparapiBuffer.h
+++ b/com.amd.aparapi.jni/src/cpp/runKernel/AparapiBuffer.h
@@ -70,10 +70,12 @@ private:
       return (type&com_amd_aparapi_internal_jni_KernelRunnerJNI_ARG_SHORT);
    }
 
+   void buildBuffer(void* _data, cl_uint* _dims, cl_uint _numDims, long _lengthInBytes, jobject _javaObject);
+
 public:
       jobject javaObject;       // The java array that this arg is mapped to 
-      cl_uint numDims;          // sizes of dimensions of the object (array lengths for ND arrays)
-      cl_uint* dims;            // sizes of offsets of the object (first element offset in ND arrays)
+      cl_uint numDims;          // number of dimensions of the object (array lengths for ND arrays)
+      cl_uint* offsets;         // offsets of the next element in ND arrays)
       cl_uint* lens;            // sizes of dimensions of the object (array lengths for ND arrays)
       jint lengthInBytes;       // bytes in the array or directBuf
       cl_mem mem;               // the opencl buffer 
@@ -87,25 +89,25 @@ public:
 
       void deleteBuffer(KernelArg* arg);
 
-      static AparapiBuffer* flatten(JNIEnv *env, jobject arg, int type);
+      void flatten(JNIEnv *env, KernelArg* arg);
 
-      static AparapiBuffer* flattenBoolean2D(JNIEnv *env, jobject arg);
-      static AparapiBuffer* flattenChar2D(JNIEnv *env, jobject arg);
-      static AparapiBuffer* flattenByte2D(JNIEnv *env, jobject arg);
-      static AparapiBuffer* flattenShort2D(JNIEnv *env, jobject arg);
-      static AparapiBuffer* flattenInt2D(JNIEnv *env, jobject arg);
-      static AparapiBuffer* flattenLong2D(JNIEnv *env, jobject arg);
-      static AparapiBuffer* flattenFloat2D(JNIEnv *env, jobject arg);
-      static AparapiBuffer* flattenDouble2D(JNIEnv *env, jobject arg);
+      void flattenBoolean2D(JNIEnv *env, KernelArg* arg);
+      void flattenChar2D(JNIEnv *env, KernelArg* arg);
+      void flattenByte2D(JNIEnv *env, KernelArg* arg);
+      void flattenShort2D(JNIEnv *env, KernelArg* arg);
+      void flattenInt2D(JNIEnv *env, KernelArg* arg);
+      void flattenLong2D(JNIEnv *env, KernelArg* arg);
+      void flattenFloat2D(JNIEnv *env, KernelArg* arg);
+      void flattenDouble2D(JNIEnv *env, KernelArg* arg);
 
-      static AparapiBuffer* flattenBoolean3D(JNIEnv *env, jobject arg);
-      static AparapiBuffer* flattenChar3D(JNIEnv *env, jobject arg);
-      static AparapiBuffer* flattenByte3D(JNIEnv *env, jobject arg);
-      static AparapiBuffer* flattenShort3D(JNIEnv *env, jobject arg);
-      static AparapiBuffer* flattenInt3D(JNIEnv *env, jobject arg);
-      static AparapiBuffer* flattenLong3D(JNIEnv *env, jobject arg);
-      static AparapiBuffer* flattenFloat3D(JNIEnv *env, jobject arg);
-      static AparapiBuffer* flattenDouble3D(JNIEnv *env, jobject arg);
+      void flattenBoolean3D(JNIEnv *env, KernelArg* arg);
+      void flattenChar3D(JNIEnv *env, KernelArg* arg);
+      void flattenByte3D(JNIEnv *env, KernelArg* arg);
+      void flattenShort3D(JNIEnv *env, KernelArg* arg);
+      void flattenInt3D(JNIEnv *env, KernelArg* arg);
+      void flattenLong3D(JNIEnv *env, KernelArg* arg);
+      void flattenFloat3D(JNIEnv *env, KernelArg* arg);
+      void flattenDouble3D(JNIEnv *env, KernelArg* arg);
 
       void inflate(JNIEnv *env, KernelArg* arg);
 

--- a/com.amd.aparapi.jni/src/cpp/runKernel/KernelArg.cpp
+++ b/com.amd.aparapi.jni/src/cpp/runKernel/KernelArg.cpp
@@ -35,7 +35,7 @@ KernelArg::KernelArg(JNIEnv *jenv, JNIContext *jniContext, jobject argObj):
       if (isArray()){
          arrayBuffer = new ArrayBuffer();
       } else if(isAparapiBuffer()) {
-         aparapiBuffer = AparapiBuffer::flatten(jenv, argObj, type);
+         aparapiBuffer = new AparapiBuffer();
       }
    }
 

--- a/com.amd.aparapi.jni/src/cpp/runKernel/KernelArg.h
+++ b/com.amd.aparapi.jni/src/cpp/runKernel/KernelArg.h
@@ -64,7 +64,7 @@ class KernelArg{
       static jfieldID javaArrayFieldID; 
    public:
       JNIContext *jniContext;  
-      jobject argObj;    // the Java KernelRunner.KernelArg object that we are mirroring.
+      jobject argObj;    // the Java KernelRunner.KernelArg object that we are mirroring. Do not use it outside constructor due to GC. Use javaArg instead.
       jobject javaArg;   // global reference to the corresponding java KernelArg object we grabbed our own global reference so that the object won't be collected until we dispose!
       char *name;        // used for debugging printfs
       jint type;         // a bit mask determining the type of this arg


### PR DESCRIPTION
This patch resolves the issue https://code.google.com/p/aparapi/issues/detail?id=144, which raises the exception when calling kernel.dispose() of 2D/3D array. The patch also allows re-execute of the kernel.