### PR TITLE
Fixed dispose in KernelRunner.java 

### DIFF
--- a/com.amd.aparapi/src/java/com/amd/aparapi/internal/kernel/KernelRunner.java
+++ b/com.amd.aparapi/src/java/com/amd/aparapi/internal/kernel/KernelRunner.java
@@ -190,6 +190,7 @@ public class KernelRunner extends KernelRunnerJNI{
    public synchronized void dispose() {
       if (kernel.isRunningCL()) {
          disposeJNI(jniContextHandle);
+         seenBinaryKeys.clear();
       }
       // We are using a shared pool, so there's no need no shutdown it when kernel is disposed
       //      threadPool.shutdownNow();


### PR DESCRIPTION
dispose() disposes of the jniContextHandle, however the seenBinaryKeys still reported that the handle is still available. This resulted in a kernel being unable to recompile after any of it's predecessors have been disposed. Clearing this set fixes this issue.

This is a fix for issue #34 