### PR TITLE
Fix API mismatch in JNI

### DIFF
--- a/com.amd.aparapi/src/java/com/amd/aparapi/internal/jni/OpenCLJNI.java
+++ b/com.amd.aparapi/src/java/com/amd/aparapi/internal/jni/OpenCLJNI.java
@@ -17,7 +17,7 @@ public abstract class OpenCLJNI{
 
    protected native List<OpenCLPlatform> getPlatforms();
 
-   protected native OpenCLProgram createProgram(OpenCLDevice context, String openCLSource);
+   protected native OpenCLProgram createProgram(OpenCLDevice context, String openCLSource, String binaryKey);
 
    protected native OpenCLKernel createKernelJNI(OpenCLProgram program, String kernelName, OpenCLArgDescriptor[] args);
 

--- a/com.amd.aparapi/src/java/com/amd/aparapi/internal/opencl/OpenCLProgram.java
+++ b/com.amd.aparapi/src/java/com/amd/aparapi/internal/opencl/OpenCLProgram.java
@@ -5,6 +5,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import java.security.MessageDigest;
+
 import com.amd.aparapi.device.OpenCLDevice;
 import com.amd.aparapi.internal.jni.OpenCLJNI;
 
@@ -58,7 +60,16 @@ public class OpenCLProgram extends OpenCLJNI{
    }
 
    public OpenCLProgram createProgram(OpenCLDevice context) {
-      return createProgram(context, source);
+      String uniqueId;
+      try {
+         MessageDigest digest;
+         digest = MessageDigest.getInstance("SHA-256");
+         digest.digest(source.getBytes());
+         uniqueId = digest.toString();
+      } catch (java.security.NoSuchAlgorithmException e) {
+         uniqueId = ""; // "" explicitly is explicitly non-unique
+      }
+      return createProgram(context, source, uniqueId);
    }
 
    public OpenCLDevice getDevice() {


### PR DESCRIPTION
Kernels are easily identified their SHA-256 hash (which should be present on
all modern Java implementations).

Without this, the examples with OpenCL interop all fail.